### PR TITLE
Upgrade to 0.7.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM rust:slim-bullseye as cargo-build
+FROM rust:1.39.0-slim-stretch as cargo-build
 
-ARG DRILL_VERSION=0.7.2
+ARG DRILL_VERSION=0.7.1
 ARG OPENSSL_VERSION=1.0.2u
 
 RUN apt-get update && \
@@ -33,7 +33,7 @@ RUN cd /src && \
     RUSTFLAGS=-Clinker=musl-gcc cargo build --release --target=x86_64-unknown-linux-musl
 
 
-FROM alpine:latest
+FROM alpine:20190707
 
 COPY --from=cargo-build /src/drill/target/x86_64-unknown-linux-musl/release/drill /usr/local/bin/drill
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM rust:1.37-slim-stretch as cargo-build
+FROM rust:slim-bullseye as cargo-build
 
-ARG DRILL_VERSION=0.5.0
-ARG OPENSSL_VERSION=1.0.2r
+ARG DRILL_VERSION=0.7.2
+ARG OPENSSL_VERSION=1.0.2u
 
 RUN apt-get update && \
     apt-get install -y curl musl-tools make pkg-config && \
@@ -33,7 +33,7 @@ RUN cd /src && \
     RUSTFLAGS=-Clinker=musl-gcc cargo build --release --target=x86_64-unknown-linux-musl
 
 
-FROM alpine:20190707
+FROM alpine:latest
 
 COPY --from=cargo-build /src/drill/target/x86_64-unknown-linux-musl/release/drill /usr/local/bin/drill
 


### PR DESCRIPTION
Upgrading to 0.7.2 throws a sigkill even if it compiles.

0.7.1 works though so we can gain those improvements at the very least.